### PR TITLE
feat: ✨ improve multi monitor ux, add aborting with esc and more

### DIFF
--- a/Gridded/Configuration.swift
+++ b/Gridded/Configuration.swift
@@ -19,6 +19,7 @@ final class Configuration: ObservableObject {
   @Published var activateKey: Int
   @Published var constrainMouse: Bool
   @Published var moveOnActivate: Bool
+  @Published var requireWindowDragBeforeSnapping: Bool
   @Published var resetWindowOnEscape: Bool
   @Published var accessibilityPermission: Bool = false
 
@@ -34,6 +35,8 @@ final class Configuration: ObservableObject {
     activateKey = defaults.getValue(forKey: "activateKey") ?? 49
     constrainMouse = defaults.getValue(forKey: "constrainMouse") ?? true
     moveOnActivate = defaults.getValue(forKey: "moveOnActivate") ?? false
+    requireWindowDragBeforeSnapping =
+      defaults.getValue(forKey: "requireWindowDragBeforeSnapping") ?? true
     resetWindowOnEscape = defaults.getValue(forKey: "resetWindowOnEscape") ?? false
 
     $columns
@@ -66,6 +69,10 @@ final class Configuration: ObservableObject {
 
     $moveOnActivate
       .sink { defaults.set($0, forKey: "moveOnActivate") }
+      .store(in: &cancellables)
+
+    $requireWindowDragBeforeSnapping
+      .sink { defaults.set($0, forKey: "requireWindowDragBeforeSnapping") }
       .store(in: &cancellables)
 
     $resetWindowOnEscape

--- a/Gridded/Configuration.swift
+++ b/Gridded/Configuration.swift
@@ -19,6 +19,7 @@ final class Configuration: ObservableObject {
   @Published var activateKey: Int
   @Published var constrainMouse: Bool
   @Published var moveOnActivate: Bool
+  @Published var resetWindowOnEscape: Bool
   @Published var accessibilityPermission: Bool = false
 
   static let shared = Configuration()
@@ -33,6 +34,7 @@ final class Configuration: ObservableObject {
     activateKey = defaults.getValue(forKey: "activateKey") ?? 49
     constrainMouse = defaults.getValue(forKey: "constrainMouse") ?? true
     moveOnActivate = defaults.getValue(forKey: "moveOnActivate") ?? false
+    resetWindowOnEscape = defaults.getValue(forKey: "resetWindowOnEscape") ?? false
 
     $columns
       .sink { defaults.set($0, forKey: "gridColumns") }
@@ -64,6 +66,10 @@ final class Configuration: ObservableObject {
 
     $moveOnActivate
       .sink { defaults.set($0, forKey: "moveOnActivate") }
+      .store(in: &cancellables)
+
+    $resetWindowOnEscape
+      .sink { defaults.set($0, forKey: "resetWindowOnEscape") }
       .store(in: &cancellables)
 
     if defaults.object(forKey: "autoStart") == nil {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -155,8 +155,22 @@ class EventMonitor {
     logger.debug("cancel snapping")
 
     if Configuration.shared.resetWindowOnEscape {
-      restoreWindowFrameAfterEscape()
+      let window = frontMostWindow
+      let screen = activeScreen
+      let originalWindowFrame = originalWindowFrame
+
+      endActiveWindowDrag()
       reset()
+
+      if let window, let screen, let originalWindowFrame {
+        DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
+          WindowManager.shared.setWindow(
+            window: window,
+            screen: screen,
+            frame: originalWindowFrame
+          )
+        }
+      }
       return true
     }
 
@@ -344,19 +358,17 @@ class EventMonitor {
     isDragging = deltaX > Self.dragDetectionThreshold || deltaY > Self.dragDetectionThreshold
   }
 
-  private func restoreWindowFrameAfterEscape() {
-    guard let frontMostWindow,
-      let originalWindowFrame,
-      let activeScreen
-    else {
+  private func endActiveWindowDrag() {
+    guard let event = CGEvent(
+      mouseEventSource: nil,
+      mouseType: .leftMouseUp,
+      mouseCursorPosition: getMouseCoordinates(),
+      mouseButton: .left
+    ) else {
       return
     }
 
-    WindowManager.shared.setWindow(
-      window: frontMostWindow,
-      screen: activeScreen,
-      frame: originalWindowFrame
-    )
+    event.post(tap: .cghidEventTap)
   }
 
   private func constrainMouseToActiveScreen(_ mousePosition: CGPoint) {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -25,12 +25,6 @@ class EventMonitor {
 
   private let logger = Logger(label: "EventMonitor")
 
-  private func screenDebugDescription(_ screen: NSScreen?) -> String {
-    guard let screen else { return "nil" }
-    let frame = screen.frame
-    return "\(screen.localizedName) frame=(\(Int(frame.minX)),\(Int(frame.minY)) \(Int(frame.width))x\(Int(frame.height)))"
-  }
-
   public var isMonitoring: Bool { eventTap != nil }
   private var eventTap: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
@@ -167,25 +161,11 @@ class EventMonitor {
       let window = originalDraggedWindow ?? frontMostWindow
       let originalWindowAXFrame = originalWindowAXFrame
 
-      if let window {
-        logger.notice("cancelSnapping: window=\(WindowManager.shared.windowDebugDescription(window))")
-      } else {
-        logger.warning("cancelSnapping: no frontMostWindow captured")
-      }
-      if let originalWindowAXFrame {
-        logger.notice(
-          "cancelSnapping: savedAXFrame pos=(\(originalWindowAXFrame.position.x),\(originalWindowAXFrame.position.y)) size=(\(originalWindowAXFrame.size.width),\(originalWindowAXFrame.size.height)) activeScreen=\(screenDebugDescription(activeScreen))"
-        )
-      } else {
-        logger.warning("cancelSnapping: originalWindowAXFrame is nil")
-      }
-
       endActiveWindowDrag()
       reset()
 
       if let window, let originalWindowAXFrame {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-          self.logger.notice("cancelSnapping: restoring saved AX frame after delay")
           WindowManager.shared.restoreWindow(
             window: window,
             axFrame: originalWindowAXFrame
@@ -211,7 +191,6 @@ class EventMonitor {
   private func leftMouseDown() {
     reset()
     activeScreen = ScreenManager.shared.getActiveScreen()
-    logger.notice("leftMouseDown: mouse=(\(getMouseCoordinates().x),\(getMouseCoordinates().y)) activeScreen=\(screenDebugDescription(activeScreen))")
     isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
     captureWindowForCurrentDrag()
 
@@ -324,23 +303,15 @@ class EventMonitor {
     activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
     guard activeScreen != nil else { return }
 
-    let mouse = getMouseCoordinates()
-    logger.notice("startSnapping: mouse=(\(mouse.x),\(mouse.y)) activeScreen=\(screenDebugDescription(activeScreen))")
-
     if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
       ?? WindowManager.shared.getFrontmostWindow()
     {
       if let capturedWindow = frontMostWindow,
         !CFEqual(capturedWindow, snapWindow)
       {
-        logger.warning(
-          "startSnapping: captured window differs from snap window, preserving original restore target. captured=\(WindowManager.shared.windowDebugDescription(capturedWindow)) snap=\(WindowManager.shared.windowDebugDescription(snapWindow))"
-        )
+        logger.warning("startSnapping: captured window differs from snap window, preserving original restore target")
       }
-      logger.notice("startSnapping: using window=\(WindowManager.shared.windowDebugDescription(snapWindow))")
       frontMostWindow = snapWindow
-    } else {
-      logger.warning("startSnapping: failed to resolve a window")
     }
     windowCoordinatesStart = getWindowCoordinates()
     mouseCoordinatesStart = getMouseCoordinates()
@@ -367,22 +338,16 @@ class EventMonitor {
     let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
     frontMostWindow = hitWindow ?? WindowManager.shared.getFrontmostWindow()
 
-    if let hitWindow {
-      logger.notice("captureWindowForCurrentDrag: hit window=\(WindowManager.shared.windowDebugDescription(hitWindow))")
-    } else {
-      logger.warning("captureWindowForCurrentDrag: hit-test failed at mouse=(\(mouse.x),\(mouse.y)), falling back to frontmost window")
+    if hitWindow == nil {
+      logger.warning("captureWindowForCurrentDrag: hit-test failed, falling back to frontmost window")
     }
     windowCoordinatesStart = getWindowCoordinates()
     if let frontMostWindow {
       originalDraggedWindow = frontMostWindow
       originalWindowAXFrame = WindowManager.shared.getAXWindowFrame(window: frontMostWindow)
-      logger.notice(
-        "captureWindowForCurrentDrag: captured window=\(WindowManager.shared.windowDebugDescription(frontMostWindow)) savedAXFrame=\(String(describing: originalWindowAXFrame))"
-      )
     } else {
       originalDraggedWindow = nil
       originalWindowAXFrame = nil
-      logger.warning("captureWindowForCurrentDrag: no window captured")
     }
   }
 
@@ -424,9 +389,6 @@ class EventMonitor {
   private func endActiveWindowDrag() {
     let cocoaMousePosition = getMouseCoordinates()
     let axMousePosition = WindowManager.shared.appKitPointToAXPoint(cocoaMousePosition)
-    logger.notice(
-      "endActiveWindowDrag: posting leftMouseUp cocoa=(\(cocoaMousePosition.x),\(cocoaMousePosition.y)) ax=(\(axMousePosition.x),\(axMousePosition.y))"
-    )
 
     guard let event = CGEvent(
       mouseEventSource: nil,

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -189,15 +189,27 @@ class EventMonitor {
 
   private func leftMouseDown() {
     reset()
+    let mouse = getMouseCoordinates()
     activeScreen = ScreenManager.shared.getActiveScreen()
+    logger.debug("leftMouseDown: mouse=(\(mouse.x), \(mouse.y)) screen=\(activeScreen?.localizedName ?? "nil")")
     isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
     captureWindowForCurrentDrag()
 
-    // Refresh after the mouse-down event propagates so focus changes are reflected.
-    DispatchQueue.main.async { [weak self] in
-      guard let self else { return }
-      guard !self.isSnapping else { return }
-      self.captureWindowForCurrentDrag()
+    // Only async-refresh if the sync capture found nothing — do NOT overwrite a
+    // successful capture, because by the time this fires, focus may have shifted
+    // to a different app (e.g. the window that received the click becoming active).
+    if frontMostWindow == nil {
+      DispatchQueue.main.async { [weak self] in
+        guard let self else { return }
+        guard !self.isSnapping else {
+          self.logger.debug("leftMouseDown async refresh: skipped (already snapping)")
+          return
+        }
+        self.logger.debug("leftMouseDown async refresh: no window captured yet, re-trying")
+        self.captureWindowForCurrentDrag()
+      }
+    } else {
+      logger.debug("leftMouseDown async refresh: skipped (window already captured)")
     }
   }
 
@@ -302,16 +314,33 @@ class EventMonitor {
     isSnapping = true
     activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
     guard activeScreen != nil else { return }
-    if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
-      ?? WindowManager.shared.getFrontmostWindow()
-    {
-      if let capturedWindow = frontMostWindow,
-        !CFEqual(capturedWindow, snapWindow)
-      {
-        // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
-        originalWindowFrame = nil
+
+    let mouse = getMouseCoordinates()
+    let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
+    let snapWindow = hitWindow ?? WindowManager.shared.getFrontmostWindow()
+
+    logger.debug("startSnapping: mouse=(\(mouse.x), \(mouse.y))")
+    if let hitWindow {
+      logger.debug("startSnapping: hit-test window → \(WindowManager.shared.windowDebugDescription(hitWindow))")
+    } else {
+      logger.warning("startSnapping: hit-test FAILED at snap time")
+    }
+
+    if let snapWindow {
+      if let capturedWindow = frontMostWindow {
+        let same = CFEqual(capturedWindow, snapWindow)
+        logger.debug("startSnapping: captured=\(WindowManager.shared.windowDebugDescription(capturedWindow)), snapWindow=\(WindowManager.shared.windowDebugDescription(snapWindow)), same=\(same)")
+        if !same {
+          logger.warning("startSnapping: MISMATCH — captured window differs from snap window → clearing originalWindowFrame")
+          // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
+          originalWindowFrame = nil
+        }
+      } else {
+        logger.warning("startSnapping: no captured window at snap time, using snap window → \(WindowManager.shared.windowDebugDescription(snapWindow))")
       }
       frontMostWindow = snapWindow
+    } else {
+      logger.warning("startSnapping: no window found at snap time (hit-test and frontmost both failed)")
     }
     windowCoordinatesStart = getWindowCoordinates()
     mouseCoordinatesStart = getMouseCoordinates()
@@ -334,13 +363,30 @@ class EventMonitor {
   }
 
   private func captureWindowForCurrentDrag() {
-    frontMostWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
-      ?? WindowManager.shared.getFrontmostWindow()
+    let mouse = getMouseCoordinates()
+    logger.debug("captureWindowForCurrentDrag: mouse=(\(mouse.x), \(mouse.y))")
+
+    let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
+    if let hitWindow {
+      logger.debug("captureWindowForCurrentDrag: hit-test found → \(WindowManager.shared.windowDebugDescription(hitWindow))")
+      frontMostWindow = hitWindow
+    } else {
+      let frontmost = WindowManager.shared.getFrontmostWindow()
+      if let frontmost {
+        logger.warning("captureWindowForCurrentDrag: hit-test FAILED — falling back to frontmost window → \(WindowManager.shared.windowDebugDescription(frontmost))")
+      } else {
+        logger.warning("captureWindowForCurrentDrag: both hit-test and frontmost FAILED — no window captured")
+      }
+      frontMostWindow = frontmost
+    }
+
     windowCoordinatesStart = getWindowCoordinates()
     if let frontMostWindow {
       originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
+      logger.debug("captureWindowForCurrentDrag: captured window originalFrame=\(String(describing: originalWindowFrame))")
     } else {
       originalWindowFrame = nil
+      logger.warning("captureWindowForCurrentDrag: no window captured, originalWindowFrame=nil")
     }
   }
 

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -20,6 +20,8 @@ import Logging
 class EventMonitor {
   static let shared = EventMonitor()
 
+  private static let escapeKeyCode: Int64 = 53
+
   private let logger = Logger(label: "EventMonitor")
 
   public var isMonitoring: Bool { eventTap != nil }
@@ -35,6 +37,7 @@ class EventMonitor {
   private var mouseCoordinatesEnd: CGPoint? = nil
   private var windowCoordinatesStart: CGPoint? = nil
   private var windowCoordinatesEnd: CGPoint? = nil
+  private var originalWindowFrame: CGRect? = nil
   public private(set) var activeScreen: NSScreen? = nil
   private var snapToCoordinates: CGRect? = nil
 
@@ -73,6 +76,7 @@ class EventMonitor {
       eventsOfInterest: CGEventMask(eventMask),
       callback: { _, type, event, refcon in
         let handledEvent = EventMonitor.shared.handle(event: event, type: type)
+        guard let handledEvent else { return nil }
         return Unmanaged.passUnretained(handledEvent)
       },
       userInfo: nil
@@ -110,7 +114,7 @@ class EventMonitor {
 
   // MARK: Event handlers
 
-  private func handle(event: CGEvent, type: CGEventType) -> CGEvent {
+  private func handle(event: CGEvent, type: CGEventType) -> CGEvent? {
     let activateKey = Configuration.shared.activateKey
     switch type {
     case .leftMouseDown:
@@ -128,7 +132,12 @@ class EventMonitor {
       logger.debug("right mouse down")
       startSnapping()
     case .keyDown:
-      if event.getIntegerValueField(.keyboardEventKeycode) == activateKey {
+      let keyCode = event.getIntegerValueField(.keyboardEventKeycode)
+      if keyCode == Self.escapeKeyCode, cancelSnapping() {
+        logger.debug("escape down")
+        return nil
+      }
+      if keyCode == activateKey {
         logger.debug("space down")
         startSnapping()
       }
@@ -139,10 +148,38 @@ class EventMonitor {
     return event
   }
 
+  @discardableResult
+  private func cancelSnapping() -> Bool {
+    guard isSnapping else { return false }
+    logger.debug("cancel snapping")
+
+    if Configuration.shared.resetWindowOnEscape {
+      restoreWindowFrameAfterEscape()
+      reset()
+      return true
+    }
+
+    mouseCoordinatesEnd = nil
+    mouseCoordinatesStart = nil
+    isSnapping = false
+    snapToCoordinates = nil
+
+    if overlayWindow != nil {
+      overlayWindow?.orderOut(nil)
+      overlayWindow = nil
+    }
+
+    return true
+  }
+
   private func leftMouseDown() {
     reset()
     activeScreen = ScreenManager.shared.getActiveScreen()
     isDragging = true
+    frontMostWindow = WindowManager.shared.getFrontmostWindow()
+    if let frontMostWindow {
+      originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
+    }
   }
 
   private func leftMouseUp() {
@@ -198,6 +235,7 @@ class EventMonitor {
     windowCoordinatesEnd = nil
     windowCoordinatesStart = nil
     frontMostWindow = nil
+    originalWindowFrame = nil
     isDragging = false
     isSnapping = false
     activeScreen = nil
@@ -233,6 +271,21 @@ class EventMonitor {
       )
     }
     updateOverlayPreview(snapToCoordinates: snapToCoordinates!)
+  }
+
+  private func restoreWindowFrameAfterEscape() {
+    guard let frontMostWindow,
+      let originalWindowFrame,
+      let activeScreen
+    else {
+      return
+    }
+
+    WindowManager.shared.setWindow(
+      window: frontMostWindow,
+      screen: activeScreen,
+      frame: originalWindowFrame
+    )
   }
 
   private func constrainMouseToActiveScreen(_ mousePosition: CGPoint) {
@@ -277,8 +330,8 @@ class EventMonitor {
 
   private func updateOverlayPreview(snapToCoordinates: CGRect) {
     guard isSnapping, let activeScreen = activeScreen,
-      let mouseStart = mouseCoordinatesStart,
-      let mouseEnd = mouseCoordinatesEnd
+      mouseCoordinatesStart != nil,
+      mouseCoordinatesEnd != nil
     else {
       return
     }

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -191,11 +191,8 @@ class EventMonitor {
 
   private func leftMouseDown() {
     reset()
-    let mouse = getMouseCoordinates()
     activeScreen = ScreenManager.shared.getActiveScreen()
-    logger.debug("leftMouseDown: mouse=(\(mouse.x), \(mouse.y)) screen=\(activeScreen?.localizedName ?? "nil")")
     isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
-    logger.debug("leftMouseDown: isDragging set to \(isDragging) (requireDragFirst=\(Configuration.shared.requireWindowDragBeforeSnapping))")
     captureWindowForCurrentDrag()
 
     // Only async-refresh if the sync capture found nothing — do NOT overwrite a
@@ -203,16 +200,9 @@ class EventMonitor {
     // to a different app (e.g. the window that received the click becoming active).
     if frontMostWindow == nil {
       DispatchQueue.main.async { [weak self] in
-        guard let self else { return }
-        guard !self.isSnapping else {
-          self.logger.debug("leftMouseDown async refresh: skipped (already snapping)")
-          return
-        }
-        self.logger.debug("leftMouseDown async refresh: no window captured yet, re-trying")
+        guard let self, !self.isSnapping else { return }
         self.captureWindowForCurrentDrag()
       }
-    } else {
-      logger.debug("leftMouseDown async refresh: skipped (window already captured)")
     }
   }
 
@@ -303,54 +293,26 @@ class EventMonitor {
   }
 
   private func startSnapping() {
-    logger.debug("startSnapping: isDragging=\(isDragging) requireDragFirst=\(Configuration.shared.requireWindowDragBeforeSnapping) frontMostWindow=\(frontMostWindow != nil ? "set" : "nil")")
-
     if Configuration.shared.requireWindowDragBeforeSnapping {
       updateDraggingState()
-      logger.debug("startSnapping: after updateDraggingState isDragging=\(isDragging)")
-      guard isDragging else {
-        logger.warning("startSnapping: ABORTED — requireWindowDragBeforeSnapping is on but window has not moved enough yet")
-        return
-      }
+      guard isDragging else { return }
     }
 
-    guard isDragging else {
-      logger.warning("startSnapping: ABORTED — isDragging=false (was requireWindowDragBeforeSnapping off but mouseDown not received yet?)")
-      return
-    }
+    guard isDragging else { return }
     isSnapping = true
     activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
-    guard activeScreen != nil else {
-      logger.warning("startSnapping: ABORTED — no active screen")
-      return
-    }
+    guard activeScreen != nil else { return }
 
-    let mouse = getMouseCoordinates()
-    let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
-    let snapWindow = hitWindow ?? WindowManager.shared.getFrontmostWindow()
-
-    logger.debug("startSnapping: mouse=(\(mouse.x), \(mouse.y))")
-    if let hitWindow {
-      logger.debug("startSnapping: hit-test window → \(WindowManager.shared.windowDebugDescription(hitWindow))")
-    } else {
-      logger.warning("startSnapping: hit-test FAILED at snap time")
-    }
-
-    if let snapWindow {
-      if let capturedWindow = frontMostWindow {
-        let same = CFEqual(capturedWindow, snapWindow)
-        logger.debug("startSnapping: captured=\(WindowManager.shared.windowDebugDescription(capturedWindow)), snapWindow=\(WindowManager.shared.windowDebugDescription(snapWindow)), same=\(same)")
-        if !same {
-          logger.warning("startSnapping: MISMATCH — captured window differs from snap window → clearing originalWindowFrame")
-          // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
-          originalWindowFrame = nil
-        }
-      } else {
-        logger.warning("startSnapping: no captured window at snap time, using snap window → \(WindowManager.shared.windowDebugDescription(snapWindow))")
+    if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
+      ?? WindowManager.shared.getFrontmostWindow()
+    {
+      if let capturedWindow = frontMostWindow,
+        !CFEqual(capturedWindow, snapWindow)
+      {
+        // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
+        originalWindowFrame = nil
       }
       frontMostWindow = snapWindow
-    } else {
-      logger.warning("startSnapping: no window found at snap time (hit-test and frontmost both failed)")
     }
     windowCoordinatesStart = getWindowCoordinates()
     mouseCoordinatesStart = getMouseCoordinates()
@@ -373,30 +335,13 @@ class EventMonitor {
   }
 
   private func captureWindowForCurrentDrag() {
-    let mouse = getMouseCoordinates()
-    logger.debug("captureWindowForCurrentDrag: mouse=(\(mouse.x), \(mouse.y))")
-
-    let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
-    if let hitWindow {
-      logger.debug("captureWindowForCurrentDrag: hit-test found → \(WindowManager.shared.windowDebugDescription(hitWindow))")
-      frontMostWindow = hitWindow
-    } else {
-      let frontmost = WindowManager.shared.getFrontmostWindow()
-      if let frontmost {
-        logger.warning("captureWindowForCurrentDrag: hit-test FAILED — falling back to frontmost window → \(WindowManager.shared.windowDebugDescription(frontmost))")
-      } else {
-        logger.warning("captureWindowForCurrentDrag: both hit-test and frontmost FAILED — no window captured")
-      }
-      frontMostWindow = frontmost
-    }
-
+    frontMostWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
+      ?? WindowManager.shared.getFrontmostWindow()
     windowCoordinatesStart = getWindowCoordinates()
     if let frontMostWindow {
       originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
-      logger.debug("captureWindowForCurrentDrag: captured window originalFrame=\(String(describing: originalWindowFrame))")
     } else {
       originalWindowFrame = nil
-      logger.warning("captureWindowForCurrentDrag: no window captured, originalWindowFrame=nil")
     }
   }
 
@@ -407,13 +352,11 @@ class EventMonitor {
     }
 
     guard let frontMostWindow else {
-      logger.warning("updateDraggingState: no frontMostWindow → isDragging=false")
       isDragging = false
       return
     }
 
     guard let windowCoordinatesStart else {
-      logger.warning("updateDraggingState: no windowCoordinatesStart → isDragging=false")
       isDragging = false
       return
     }
@@ -426,7 +369,6 @@ class EventMonitor {
       let value,
       AXValueGetType(value as! AXValue) == .cgPoint
     else {
-      logger.warning("updateDraggingState: failed to read window position → isDragging=false")
       isDragging = false
       return
     }
@@ -435,9 +377,7 @@ class EventMonitor {
 
     let deltaX = abs(currentWindowPosition.x - windowCoordinatesStart.x)
     let deltaY = abs(currentWindowPosition.y - windowCoordinatesStart.y)
-    let threshold = Self.dragDetectionThreshold
-    isDragging = deltaX > threshold || deltaY > threshold
-    logger.debug("updateDraggingState: start=\(windowCoordinatesStart) current=\(currentWindowPosition) delta=(\(deltaX), \(deltaY)) threshold=\(threshold) → isDragging=\(isDragging)")
+    isDragging = deltaX > Self.dragDetectionThreshold || deltaY > Self.dragDetectionThreshold
   }
 
   private func endActiveWindowDrag() {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -231,23 +231,43 @@ class EventMonitor {
     }
 
     guard isSnapping else { return reset() }
-    let currentMouse = getMouseCoordinates()
+    var currentMouse = getMouseCoordinates()
+    let hoveredScreen = ScreenManager.shared.getScreen(at: currentMouse)
+
+    if let hoveredScreen,
+      let previousScreen = activeScreen,
+      previousScreen != hoveredScreen
+    {
+      logger.debug("active screen changed during drag")
+      overlayWindow?.orderOut(nil)
+      overlayWindow = nil
+    }
 
     // Only constrain the mouse if the user has enabled this setting
     if Configuration.shared.constrainMouse {
-      constrainMouseToActiveScreen(currentMouse)
+      currentMouse = constrainMouseForSnapping(
+        currentMouse,
+        hoveredScreen: hoveredScreen
+      )
     }
+
+    if hoveredScreen != nil {
+      activeScreen = ScreenManager.shared.getScreen(at: currentMouse) ?? hoveredScreen ?? activeScreen
+    }
+
+    guard let activeScreen else { return }
+
     mouseCoordinatesEnd = currentMouse
 
     snapToCoordinates = ScreenManager.shared.convertCoordinates(
       coords: (start: mouseCoordinatesStart!, end: mouseCoordinatesEnd!),
-      screen: activeScreen!
+      screen: activeScreen
     )
     updateOverlayPreview(snapToCoordinates: snapToCoordinates!)
     if Configuration.shared.moveOnActivate {
       WindowManager.shared.setWindow(
         window: self.frontMostWindow!,
-        screen: activeScreen!,
+        screen: activeScreen,
         frame: snapToCoordinates!
       )
     }
@@ -280,6 +300,7 @@ class EventMonitor {
 
     guard isDragging else { return }
     isSnapping = true
+    activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
     guard activeScreen != nil else { return }
     if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
       ?? WindowManager.shared.getFrontmostWindow()
@@ -371,44 +392,23 @@ class EventMonitor {
     event.post(tap: .cghidEventTap)
   }
 
-  private func constrainMouseToActiveScreen(_ mousePosition: CGPoint) {
-    guard let activeScreen = activeScreen else { return }
-
-    // Get the screen frame in global coordinates
-    let visibleFrame = activeScreen.visibleFrame
-
-    let margin: CGFloat = 5
-
-    let minX = visibleFrame.minX + margin
-    let maxX = visibleFrame.maxX - margin
-    let minY = visibleFrame.minY + margin
-    let maxY = visibleFrame.maxY - margin
-
-    // Constrain the mouse position to the screen bounds
-    var newMousePosition = mousePosition
-
-    var moved: Bool = false
-    if mousePosition.x > maxX {
-      newMousePosition.x = maxX
-      moved = true
-    }
-    if mousePosition.x < minX {
-      newMousePosition.x = minX
-      moved = true
-    }
-    if mousePosition.y > maxY {
-      newMousePosition.y = maxY
-      moved = true
-    }
-    if mousePosition.y < minY {
-      newMousePosition.y = minY
-      moved = true
+  private func constrainMouseForSnapping(_ mousePosition: CGPoint, hoveredScreen: NSScreen?) -> CGPoint {
+    // If the pointer is on any screen, do not interfere; this preserves cross-monitor dragging.
+    if hoveredScreen != nil {
+      return mousePosition
     }
 
-    if moved {
-      newMousePosition.y = activeScreen.frame.maxY - newMousePosition.y
-      CGWarpMouseCursorPosition(newMousePosition)
-    }
+    guard let activeScreen else { return mousePosition }
+
+    let frame = activeScreen.visibleFrame
+    let margin: CGFloat = 3
+    let clamped = CGPoint(
+      x: min(max(mousePosition.x, frame.minX + margin), frame.maxX - margin),
+      y: min(max(mousePosition.y, frame.minY + margin), frame.maxY - margin)
+    )
+
+    // Use logical clamping only; physical cursor warping causes monitor hops on some layouts.
+    return clamped
   }
 
   private func updateOverlayPreview(snapToCoordinates: CGRect) {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -21,6 +21,7 @@ class EventMonitor {
   static let shared = EventMonitor()
 
   private static let escapeKeyCode: Int64 = 53
+  private static let dragDetectionThreshold: CGFloat = 2
 
   private let logger = Logger(label: "EventMonitor")
 
@@ -175,10 +176,14 @@ class EventMonitor {
   private func leftMouseDown() {
     reset()
     activeScreen = ScreenManager.shared.getActiveScreen()
-    isDragging = true
-    frontMostWindow = WindowManager.shared.getFrontmostWindow()
-    if let frontMostWindow {
-      originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
+    isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
+    captureWindowForCurrentDrag()
+
+    // Refresh after the mouse-down event propagates so focus changes are reflected.
+    DispatchQueue.main.async { [weak self] in
+      guard let self else { return }
+      guard !self.isSnapping else { return }
+      self.captureWindowForCurrentDrag()
     }
   }
 
@@ -206,6 +211,11 @@ class EventMonitor {
   }
 
   private func leftMouseDragged() {
+    if !isSnapping {
+      updateDraggingState()
+      return
+    }
+
     guard isSnapping else { return reset() }
     let currentMouse = getMouseCoordinates()
 
@@ -249,10 +259,25 @@ class EventMonitor {
   }
 
   private func startSnapping() {
+    if Configuration.shared.requireWindowDragBeforeSnapping {
+      updateDraggingState()
+      guard isDragging else { return }
+    }
+
     guard isDragging else { return }
     isSnapping = true
     guard activeScreen != nil else { return }
-    frontMostWindow = WindowManager.shared.getFrontmostWindow()
+    if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
+      ?? WindowManager.shared.getFrontmostWindow()
+    {
+      if let capturedWindow = frontMostWindow,
+        !CFEqual(capturedWindow, snapWindow)
+      {
+        // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
+        originalWindowFrame = nil
+      }
+      frontMostWindow = snapWindow
+    }
     windowCoordinatesStart = getWindowCoordinates()
     mouseCoordinatesStart = getMouseCoordinates()
     mouseCoordinatesEnd = mouseCoordinatesStart
@@ -271,6 +296,52 @@ class EventMonitor {
       )
     }
     updateOverlayPreview(snapToCoordinates: snapToCoordinates!)
+  }
+
+  private func captureWindowForCurrentDrag() {
+    frontMostWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
+      ?? WindowManager.shared.getFrontmostWindow()
+    windowCoordinatesStart = getWindowCoordinates()
+    if let frontMostWindow {
+      originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
+    } else {
+      originalWindowFrame = nil
+    }
+  }
+
+  private func updateDraggingState() {
+    guard Configuration.shared.requireWindowDragBeforeSnapping else {
+      isDragging = true
+      return
+    }
+
+    guard let frontMostWindow else {
+      isDragging = false
+      return
+    }
+
+    guard let windowCoordinatesStart else {
+      isDragging = false
+      return
+    }
+
+    var currentWindowPosition = CGPoint.zero
+    var value: AnyObject?
+
+    guard AXUIElementCopyAttributeValue(frontMostWindow, kAXPositionAttribute as CFString, &value)
+      == .success,
+      let value,
+      AXValueGetType(value as! AXValue) == .cgPoint
+    else {
+      isDragging = false
+      return
+    }
+
+    AXValueGetValue(value as! AXValue, .cgPoint, &currentWindowPosition)
+
+    let deltaX = abs(currentWindowPosition.x - windowCoordinatesStart.x)
+    let deltaY = abs(currentWindowPosition.y - windowCoordinatesStart.y)
+    isDragging = deltaX > Self.dragDetectionThreshold || deltaY > Self.dragDetectionThreshold
   }
 
   private func restoreWindowFrameAfterEscape() {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -21,7 +21,7 @@ class EventMonitor {
   static let shared = EventMonitor()
 
   private static let escapeKeyCode: Int64 = 53
-  private static let dragDetectionThreshold: CGFloat = 2
+  private static let dragDetectionThreshold: CGFloat = 0
 
   private let logger = Logger(label: "EventMonitor")
 
@@ -128,6 +128,8 @@ class EventMonitor {
       if isSnapping {
         logger.debug("left mouse dragged")
         leftMouseDragged()
+      } else {
+        updateDraggingState()
       }
     case .rightMouseDown:
       logger.debug("right mouse down")
@@ -193,6 +195,7 @@ class EventMonitor {
     activeScreen = ScreenManager.shared.getActiveScreen()
     logger.debug("leftMouseDown: mouse=(\(mouse.x), \(mouse.y)) screen=\(activeScreen?.localizedName ?? "nil")")
     isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
+    logger.debug("leftMouseDown: isDragging set to \(isDragging) (requireDragFirst=\(Configuration.shared.requireWindowDragBeforeSnapping))")
     captureWindowForCurrentDrag()
 
     // Only async-refresh if the sync capture found nothing — do NOT overwrite a
@@ -237,11 +240,6 @@ class EventMonitor {
   }
 
   private func leftMouseDragged() {
-    if !isSnapping {
-      updateDraggingState()
-      return
-    }
-
     guard isSnapping else { return reset() }
     var currentMouse = getMouseCoordinates()
     let hoveredScreen = ScreenManager.shared.getScreen(at: currentMouse)
@@ -305,15 +303,27 @@ class EventMonitor {
   }
 
   private func startSnapping() {
+    logger.debug("startSnapping: isDragging=\(isDragging) requireDragFirst=\(Configuration.shared.requireWindowDragBeforeSnapping) frontMostWindow=\(frontMostWindow != nil ? "set" : "nil")")
+
     if Configuration.shared.requireWindowDragBeforeSnapping {
       updateDraggingState()
-      guard isDragging else { return }
+      logger.debug("startSnapping: after updateDraggingState isDragging=\(isDragging)")
+      guard isDragging else {
+        logger.warning("startSnapping: ABORTED — requireWindowDragBeforeSnapping is on but window has not moved enough yet")
+        return
+      }
     }
 
-    guard isDragging else { return }
+    guard isDragging else {
+      logger.warning("startSnapping: ABORTED — isDragging=false (was requireWindowDragBeforeSnapping off but mouseDown not received yet?)")
+      return
+    }
     isSnapping = true
     activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
-    guard activeScreen != nil else { return }
+    guard activeScreen != nil else {
+      logger.warning("startSnapping: ABORTED — no active screen")
+      return
+    }
 
     let mouse = getMouseCoordinates()
     let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
@@ -397,11 +407,13 @@ class EventMonitor {
     }
 
     guard let frontMostWindow else {
+      logger.warning("updateDraggingState: no frontMostWindow → isDragging=false")
       isDragging = false
       return
     }
 
     guard let windowCoordinatesStart else {
+      logger.warning("updateDraggingState: no windowCoordinatesStart → isDragging=false")
       isDragging = false
       return
     }
@@ -414,6 +426,7 @@ class EventMonitor {
       let value,
       AXValueGetType(value as! AXValue) == .cgPoint
     else {
+      logger.warning("updateDraggingState: failed to read window position → isDragging=false")
       isDragging = false
       return
     }
@@ -422,7 +435,9 @@ class EventMonitor {
 
     let deltaX = abs(currentWindowPosition.x - windowCoordinatesStart.x)
     let deltaY = abs(currentWindowPosition.y - windowCoordinatesStart.y)
-    isDragging = deltaX > Self.dragDetectionThreshold || deltaY > Self.dragDetectionThreshold
+    let threshold = Self.dragDetectionThreshold
+    isDragging = deltaX > threshold || deltaY > threshold
+    logger.debug("updateDraggingState: start=\(windowCoordinatesStart) current=\(currentWindowPosition) delta=(\(deltaX), \(deltaY)) threshold=\(threshold) → isDragging=\(isDragging)")
   }
 
   private func endActiveWindowDrag() {

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -25,6 +25,12 @@ class EventMonitor {
 
   private let logger = Logger(label: "EventMonitor")
 
+  private func screenDebugDescription(_ screen: NSScreen?) -> String {
+    guard let screen else { return "nil" }
+    let frame = screen.frame
+    return "\(screen.localizedName) frame=(\(Int(frame.minX)),\(Int(frame.minY)) \(Int(frame.width))x\(Int(frame.height)))"
+  }
+
   public var isMonitoring: Bool { eventTap != nil }
   private var eventTap: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
@@ -34,11 +40,12 @@ class EventMonitor {
   private var isDragging: Bool = false
   private var isSnapping: Bool = false
   private var frontMostWindow: AXUIElement? = nil
+  private var originalDraggedWindow: AXUIElement? = nil
   private var mouseCoordinatesStart: CGPoint? = nil
   private var mouseCoordinatesEnd: CGPoint? = nil
   private var windowCoordinatesStart: CGPoint? = nil
   private var windowCoordinatesEnd: CGPoint? = nil
-  private var originalWindowFrame: CGRect? = nil
+  private var originalWindowAXFrame: AXWindowFrame? = nil
   public private(set) var activeScreen: NSScreen? = nil
   private var snapToCoordinates: CGRect? = nil
 
@@ -157,19 +164,31 @@ class EventMonitor {
     logger.debug("cancel snapping")
 
     if Configuration.shared.resetWindowOnEscape {
-      let window = frontMostWindow
-      let screen = activeScreen
-      let originalWindowFrame = originalWindowFrame
+      let window = originalDraggedWindow ?? frontMostWindow
+      let originalWindowAXFrame = originalWindowAXFrame
+
+      if let window {
+        logger.notice("cancelSnapping: window=\(WindowManager.shared.windowDebugDescription(window))")
+      } else {
+        logger.warning("cancelSnapping: no frontMostWindow captured")
+      }
+      if let originalWindowAXFrame {
+        logger.notice(
+          "cancelSnapping: savedAXFrame pos=(\(originalWindowAXFrame.position.x),\(originalWindowAXFrame.position.y)) size=(\(originalWindowAXFrame.size.width),\(originalWindowAXFrame.size.height)) activeScreen=\(screenDebugDescription(activeScreen))"
+        )
+      } else {
+        logger.warning("cancelSnapping: originalWindowAXFrame is nil")
+      }
 
       endActiveWindowDrag()
       reset()
 
-      if let window, let screen, let originalWindowFrame {
+      if let window, let originalWindowAXFrame {
         DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
-          WindowManager.shared.setWindow(
+          self.logger.notice("cancelSnapping: restoring saved AX frame after delay")
+          WindowManager.shared.restoreWindow(
             window: window,
-            screen: screen,
-            frame: originalWindowFrame
+            axFrame: originalWindowAXFrame
           )
         }
       }
@@ -192,6 +211,7 @@ class EventMonitor {
   private func leftMouseDown() {
     reset()
     activeScreen = ScreenManager.shared.getActiveScreen()
+    logger.notice("leftMouseDown: mouse=(\(getMouseCoordinates().x),\(getMouseCoordinates().y)) activeScreen=\(screenDebugDescription(activeScreen))")
     isDragging = !Configuration.shared.requireWindowDragBeforeSnapping
     captureWindowForCurrentDrag()
 
@@ -279,7 +299,8 @@ class EventMonitor {
     windowCoordinatesEnd = nil
     windowCoordinatesStart = nil
     frontMostWindow = nil
-    originalWindowFrame = nil
+    originalDraggedWindow = nil
+    originalWindowAXFrame = nil
     isDragging = false
     isSnapping = false
     activeScreen = nil
@@ -303,16 +324,23 @@ class EventMonitor {
     activeScreen = ScreenManager.shared.getActiveScreen() ?? activeScreen
     guard activeScreen != nil else { return }
 
+    let mouse = getMouseCoordinates()
+    logger.notice("startSnapping: mouse=(\(mouse.x),\(mouse.y)) activeScreen=\(screenDebugDescription(activeScreen))")
+
     if let snapWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
       ?? WindowManager.shared.getFrontmostWindow()
     {
       if let capturedWindow = frontMostWindow,
         !CFEqual(capturedWindow, snapWindow)
       {
-        // We captured a different window at grab time; disable restore to avoid jumping a wrong window.
-        originalWindowFrame = nil
+        logger.warning(
+          "startSnapping: captured window differs from snap window, preserving original restore target. captured=\(WindowManager.shared.windowDebugDescription(capturedWindow)) snap=\(WindowManager.shared.windowDebugDescription(snapWindow))"
+        )
       }
+      logger.notice("startSnapping: using window=\(WindowManager.shared.windowDebugDescription(snapWindow))")
       frontMostWindow = snapWindow
+    } else {
+      logger.warning("startSnapping: failed to resolve a window")
     }
     windowCoordinatesStart = getWindowCoordinates()
     mouseCoordinatesStart = getMouseCoordinates()
@@ -335,13 +363,26 @@ class EventMonitor {
   }
 
   private func captureWindowForCurrentDrag() {
-    frontMostWindow = WindowManager.shared.getWindowAtPoint(getMouseCoordinates())
-      ?? WindowManager.shared.getFrontmostWindow()
+    let mouse = getMouseCoordinates()
+    let hitWindow = WindowManager.shared.getWindowAtPoint(mouse)
+    frontMostWindow = hitWindow ?? WindowManager.shared.getFrontmostWindow()
+
+    if let hitWindow {
+      logger.notice("captureWindowForCurrentDrag: hit window=\(WindowManager.shared.windowDebugDescription(hitWindow))")
+    } else {
+      logger.warning("captureWindowForCurrentDrag: hit-test failed at mouse=(\(mouse.x),\(mouse.y)), falling back to frontmost window")
+    }
     windowCoordinatesStart = getWindowCoordinates()
     if let frontMostWindow {
-      originalWindowFrame = WindowManager.shared.getWindowFrame(window: frontMostWindow)
+      originalDraggedWindow = frontMostWindow
+      originalWindowAXFrame = WindowManager.shared.getAXWindowFrame(window: frontMostWindow)
+      logger.notice(
+        "captureWindowForCurrentDrag: captured window=\(WindowManager.shared.windowDebugDescription(frontMostWindow)) savedAXFrame=\(String(describing: originalWindowAXFrame))"
+      )
     } else {
-      originalWindowFrame = nil
+      originalDraggedWindow = nil
+      originalWindowAXFrame = nil
+      logger.warning("captureWindowForCurrentDrag: no window captured")
     }
   }
 
@@ -381,10 +422,16 @@ class EventMonitor {
   }
 
   private func endActiveWindowDrag() {
+    let cocoaMousePosition = getMouseCoordinates()
+    let axMousePosition = WindowManager.shared.appKitPointToAXPoint(cocoaMousePosition)
+    logger.notice(
+      "endActiveWindowDrag: posting leftMouseUp cocoa=(\(cocoaMousePosition.x),\(cocoaMousePosition.y)) ax=(\(axMousePosition.x),\(axMousePosition.y))"
+    )
+
     guard let event = CGEvent(
       mouseEventSource: nil,
       mouseType: .leftMouseUp,
-      mouseCursorPosition: getMouseCoordinates(),
+      mouseCursorPosition: axMousePosition,
       mouseButton: .left
     ) else {
       return

--- a/Gridded/PreferencesView.swift
+++ b/Gridded/PreferencesView.swift
@@ -113,6 +113,19 @@ struct PreferencesView: View {
           .multilineTextAlignment(.center)
           .lineLimit(nil)
         }
+        VStack {
+          Toggle(isOn: $config.resetWindowOnEscape) {
+            Text("Pressing Escape restores the original window frame")
+          }
+          Text(
+            "Escape will move the window back to where it was when you grabbed it and will fully end the drag session until you release and grab the title bar again."
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .frame(width: 350)
+          .multilineTextAlignment(.center)
+          .lineLimit(nil)
+        }
       }
     }
   }

--- a/Gridded/PreferencesView.swift
+++ b/Gridded/PreferencesView.swift
@@ -114,6 +114,19 @@ struct PreferencesView: View {
           .lineLimit(nil)
         }
         VStack {
+          Toggle(isOn: $config.requireWindowDragBeforeSnapping) {
+            Text("Only allow snapping after the window has already moved")
+          }
+          Text(
+            "When enabled, space or secondary click will only enter grid mode after the dragged window has actually changed position."
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+          .frame(width: 350)
+          .multilineTextAlignment(.center)
+          .lineLimit(nil)
+        }
+        VStack {
           Toggle(isOn: $config.resetWindowOnEscape) {
             Text("Pressing Escape restores the original window frame")
           }

--- a/Gridded/ScreenManager.swift
+++ b/Gridded/ScreenManager.swift
@@ -16,15 +16,27 @@ class ScreenManager {
 
   public func getActiveScreen() -> NSScreen? {
     let mouseLocation = NSEvent.mouseLocation
+    return getScreen(at: mouseLocation)
+  }
 
+  public func getScreen(at point: CGPoint) -> NSScreen? {
     for screen in NSScreen.screens {
-      if screen.frame.contains(mouseLocation) {
+      if screen.frame.contains(point) {
         return screen
       }
     }
-
-    logger.notice("failed to determine active screen.")
     return nil
+  }
+
+  public func virtualDesktopFrame() -> CGRect {
+    return NSScreen.screens.reduce(CGRect.null) { partialResult, screen in
+      partialResult.union(screen.frame)
+    }
+  }
+
+  public func cocoaPointToQuartz(_ point: CGPoint) -> CGPoint {
+    let desktopFrame = virtualDesktopFrame()
+    return CGPoint(x: point.x, y: desktopFrame.maxY - point.y)
   }
 
   public func getScreenPadding(screen: NSScreen) -> (

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -33,37 +33,10 @@ private typealias CGSConnectionID = UInt32
       ?? 0
   }
 
-  // Returns a debug string for a window: "AppName – WindowTitle @ (x,y,w,h)"
-  public func windowDebugDescription(_ window: AXUIElement) -> String {
-    var pid: pid_t = 0
-    AXUIElementGetPid(window, &pid)
-    let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "pid:\(pid)"
-
-    var titleRef: AnyObject?
-    let title: String
-    if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
-       let t = titleRef as? String {
-      title = t.isEmpty ? "<untitled>" : t
-    } else {
-      title = "<no title>"
-    }
-
-    var posRef: AnyObject?
-    var sizeRef: AnyObject?
-    var pos = CGPoint.zero
-    var size = CGSize.zero
-    if AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRef) == .success,
-       let v = posRef { AXValueGetValue(v as! AXValue, .cgPoint, &pos) }
-    if AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
-       let v = sizeRef { AXValueGetValue(v as! AXValue, .cgSize, &size) }
-
-    return "\(appName) – \"\(title)\" @ (\(Int(pos.x)),\(Int(pos.y)) \(Int(size.width))×\(Int(size.height)))"
-  }
-
   // Returns the frontmost (active) window of the currently focused application.
   public func getFrontmostWindow() -> AXUIElement? {
     guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
-      logger.notice("getFrontmostWindow: failed to get frontmost application")
+      logger.notice("failed to get frontmost application")
       return nil
     }
 
@@ -74,12 +47,11 @@ private typealias CGSConnectionID = UInt32
       appElement, kAXFocusedWindowAttribute as CFString, &window)
 
     if result == .success, let windowElement = window {
-      let w = windowElement as! AXUIElement
-      logger.debug("getFrontmostWindow: \(windowDebugDescription(w))")
-      return w
+      logger.debug("successfully got frontmost window for app: \(frontmostApp.localizedName ?? "unknown")")
+      return (windowElement as! AXUIElement)
     }
 
-    logger.notice("getFrontmostWindow: failed for app \(frontmostApp.localizedName ?? "unknown"), error=\(result.rawValue)")
+    logger.notice("failed to get frontmost window with error: \(result.rawValue)")
     return nil
   }
 
@@ -97,26 +69,13 @@ private typealias CGSConnectionID = UInt32
       &hitElementRef
     )
 
-    logger.debug("getWindowAtPoint: AppKit(\(point.x), \(point.y)) → CG(\(point.x), \(cgY)), AX result=\(hitResult.rawValue)")
-
-    guard hitResult == .success, let hitElementRef else {
-      logger.debug("getWindowAtPoint: hit-test failed (result=\(hitResult.rawValue)) → returning nil")
-      return nil
-    }
-
-    var hitRole = "<unknown>"
-    var roleRef: AnyObject?
-    if AXUIElementCopyAttributeValue(hitElementRef, kAXRoleAttribute as CFString, &roleRef) == .success {
-      hitRole = (roleRef as? String) ?? "<unknown>"
-    }
-    logger.debug("getWindowAtPoint: hit element role=\(hitRole)")
-
-    if let window = resolveWindowElement(from: hitElementRef) {
-      logger.debug("getWindowAtPoint: resolved window → \(windowDebugDescription(window))")
+    if hitResult == .success,
+      let hitElementRef,
+      let window = resolveWindowElement(from: hitElementRef)
+    {
       return window
     }
 
-    logger.debug("getWindowAtPoint: could not resolve AXWindow from hit element → returning nil")
     return nil
   }
 

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -51,6 +51,57 @@ private typealias CGSConnectionID = UInt32
     return nil
   }
 
+  public func getWindowFrame(window: AXUIElement) -> CGRect? {
+    var pid: pid_t = 0
+    AXUIElementGetPid(window, &pid)
+
+    // Some apps only expose reliable AX frame attributes with enhanced UI mode enabled.
+    let appRef = AXUIElementCreateApplication(pid)
+    AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
+
+    var position = CGPoint.zero
+    var size = CGSize.zero
+
+    // Prefer AXFrame when available; some apps expose this more reliably than position+size.
+    var frameValueRef: AnyObject?
+    if AXUIElementCopyAttributeValue(window, "AXFrame" as CFString, &frameValueRef) == .success,
+       let frameValueRef,
+       AXValueGetType(frameValueRef as! AXValue) == .cgRect {
+      var frame = CGRect.zero
+      AXValueGetValue(frameValueRef as! AXValue, .cgRect, &frame)
+      position = frame.origin
+      size = frame.size
+    } else {
+      var positionValueRef: AnyObject?
+      var sizeValueRef: AnyObject?
+
+      guard AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &positionValueRef)
+        == .success,
+        let positionValueRef,
+        AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeValueRef) == .success,
+        let sizeValueRef,
+        AXValueGetType(positionValueRef as! AXValue) == .cgPoint,
+        AXValueGetType(sizeValueRef as! AXValue) == .cgSize
+      else {
+        logger.notice("failed to get window frame")
+        return nil
+      }
+
+      AXValueGetValue(positionValueRef as! AXValue, .cgPoint, &position)
+      AXValueGetValue(sizeValueRef as! AXValue, .cgSize, &size)
+    }
+
+    let primaryScreenHeight = NSScreen.screens.first { $0.frame.origin == .zero }?.frame.height
+      ?? NSScreen.main!.frame.height
+
+    return CGRect(
+      x: position.x,
+      y: primaryScreenHeight - position.y - size.height,
+      width: size.width,
+      height: size.height
+    )
+  }
+
   // Moves and resizes the given window to a new CGRect.
   public func setWindow(window: AXUIElement, screen: NSScreen, frame _frame: CGRect) {
     /*

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -42,23 +42,6 @@ private typealias CGSConnectionID = UInt32
     CGPoint(x: point.x, y: primaryScreenHeight() - point.y)
   }
 
-  public func windowDebugDescription(_ window: AXUIElement) -> String {
-    var pid: pid_t = 0
-    AXUIElementGetPid(window, &pid)
-    let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "pid:\(pid)"
-
-    var titleRef: AnyObject?
-    let title: String
-    if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
-       let titleValue = titleRef as? String {
-      title = titleValue.isEmpty ? "<untitled>" : titleValue
-    } else {
-      title = "<no title>"
-    }
-
-    return "\(appName) - \"\(title)\""
-  }
-
   // Returns the frontmost (active) window of the currently focused application.
   public func getFrontmostWindow() -> AXUIElement? {
     guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
@@ -73,12 +56,11 @@ private typealias CGSConnectionID = UInt32
       appElement, kAXFocusedWindowAttribute as CFString, &window)
 
     if result == .success, let windowElement = window {
-      let resolvedWindow = windowElement as! AXUIElement
-      logger.notice("getFrontmostWindow: \(self.windowDebugDescription(resolvedWindow))")
-      return resolvedWindow
+      logger.debug("successfully got frontmost window for app: \(frontmostApp.localizedName ?? "unknown")")
+      return (windowElement as! AXUIElement)
     }
 
-    logger.notice("getFrontmostWindow: failed for app \(frontmostApp.localizedName ?? "unknown"), error=\(result.rawValue)")
+    logger.notice("failed to get frontmost window with error: \(result.rawValue)")
     return nil
   }
 
@@ -96,17 +78,12 @@ private typealias CGSConnectionID = UInt32
       &hitElementRef
     )
 
-    logger.notice("getWindowAtPoint: AppKit=(\(point.x),\(point.y)) AX=(\(axPoint.x),\(axPoint.y)) result=\(hitResult.rawValue)")
-
     if hitResult == .success,
       let hitElementRef,
       let window = resolveWindowElement(from: hitElementRef)
     {
-      logger.notice("getWindowAtPoint: resolved \(self.windowDebugDescription(window))")
       return window
     }
-
-    logger.notice("getWindowAtPoint: no window resolved")
 
     return nil
   }
@@ -164,9 +141,7 @@ private typealias CGSConnectionID = UInt32
       AXValueGetValue(sizeValueRef as! AXValue, .cgSize, &size)
     }
 
-    let axFrame = AXWindowFrame(position: position, size: size)
-    logger.notice("getAXWindowFrame: \(self.windowDebugDescription(window)) -> pos=(\(position.x),\(position.y)) size=(\(size.width),\(size.height))")
-    return axFrame
+    return AXWindowFrame(position: position, size: size)
   }
 
   // Moves and resizes the given window to a new CGRect.
@@ -201,9 +176,6 @@ private typealias CGSConnectionID = UInt32
   }
 
   public func restoreWindow(window: AXUIElement, axFrame: AXWindowFrame) {
-    logger.notice(
-      "restoreWindow: \(self.windowDebugDescription(window)) -> pos=(\(axFrame.position.x),\(axFrame.position.y)) size=(\(axFrame.size.width),\(axFrame.size.height))"
-    )
     applyWindowFrame(
       window: window,
       targetPosition: axFrame.position,

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -51,6 +51,27 @@ private typealias CGSConnectionID = UInt32
     return nil
   }
 
+  public func getWindowAtPoint(_ point: CGPoint) -> AXUIElement? {
+    let systemWideElement = AXUIElementCreateSystemWide()
+    var hitElementRef: AXUIElement?
+
+    let hitResult = AXUIElementCopyElementAtPosition(
+      systemWideElement,
+      Float(point.x),
+      Float(point.y),
+      &hitElementRef
+    )
+
+    if hitResult == .success,
+      let hitElementRef,
+      let window = resolveWindowElement(from: hitElementRef)
+    {
+      return window
+    }
+
+    return nil
+  }
+
   public func getWindowFrame(window: AXUIElement) -> CGRect? {
     var pid: pid_t = 0
     AXUIElementGetPid(window, &pid)
@@ -174,5 +195,39 @@ private typealias CGSConnectionID = UInt32
         self?.applyWindowFrame(window: window, targetPosition: targetPosition, targetSize: targetSize, attempt: attempt + 1)
       }
     }
+  }
+
+  private func resolveWindowElement(from element: AXUIElement) -> AXUIElement? {
+    var windowValue: CFTypeRef?
+    if AXUIElementCopyAttributeValue(element, kAXWindowAttribute as CFString, &windowValue) == .success,
+       let windowValue,
+       CFGetTypeID(windowValue) == AXUIElementGetTypeID() {
+      return unsafeBitCast(windowValue, to: AXUIElement.self)
+    }
+
+    var current: AXUIElement? = element
+    var depth = 0
+    while let currentElement = current, depth < 10 {
+      var roleRef: AnyObject?
+      if AXUIElementCopyAttributeValue(currentElement, kAXRoleAttribute as CFString, &roleRef) == .success,
+         let role = roleRef as? String,
+         role == kAXWindowRole {
+        return currentElement
+      }
+
+      var parentValue: CFTypeRef?
+      if AXUIElementCopyAttributeValue(currentElement, kAXParentAttribute as CFString, &parentValue) != .success {
+        break
+      }
+      guard let parentValue,
+        CFGetTypeID(parentValue) == AXUIElementGetTypeID()
+      else {
+        break
+      }
+      current = unsafeBitCast(parentValue, to: AXUIElement.self)
+      depth += 1
+    }
+
+    return nil
   }
 }

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -27,6 +27,12 @@ private typealias CGSConnectionID = UInt32
 
   private let logger = Logger(label: "WindowManager")
 
+  private func primaryScreenHeight() -> CGFloat {
+    return NSScreen.screens.first { $0.frame.origin == .zero }?.frame.height
+      ?? NSScreen.main?.frame.height
+      ?? 0
+  }
+
   // Returns the frontmost (active) window of the currently focused application.
   public func getFrontmostWindow() -> AXUIElement? {
     guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
@@ -112,12 +118,11 @@ private typealias CGSConnectionID = UInt32
       AXValueGetValue(sizeValueRef as! AXValue, .cgSize, &size)
     }
 
-    let primaryScreenHeight = NSScreen.screens.first { $0.frame.origin == .zero }?.frame.height
-      ?? NSScreen.main!.frame.height
+    let primaryHeight = primaryScreenHeight()
 
     return CGRect(
       x: position.x,
-      y: primaryScreenHeight - position.y - size.height,
+      y: primaryHeight - position.y - size.height,
       width: size.width,
       height: size.height
     )
@@ -140,11 +145,10 @@ private typealias CGSConnectionID = UInt32
     // Electron and some apps respond better to AX changes with enhanced UI mode enabled
     let appRef = AXUIElementCreateApplication(pid)
     AXUIElementSetAttributeValue(appRef, "AXEnhancedUserInterface" as CFString, true as CFTypeRef)
-    let primaryScreenHeight = NSScreen.screens.first { $0.frame.origin == .zero }?.frame.height ?? NSScreen.main!.frame.height
-
+    let primaryHeight = primaryScreenHeight()
     let frame = CGRect(
       x: _frame.origin.x,
-      y: primaryScreenHeight - _frame.origin.y - _frame.height,
+      y: primaryHeight - _frame.origin.y - _frame.height,
       width: _frame.width,
       height: _frame.height
     )

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -16,6 +16,11 @@ struct SnapToCoordinates: Hashable {
   var end: CGPoint
 }
 
+struct AXWindowFrame {
+  var position: CGPoint
+  var size: CGSize
+}
+
 private typealias CGSConnectionID = UInt32
 @_silgen_name("CGSMainConnectionID") private func CGSMainConnectionID() -> CGSConnectionID
 @_silgen_name("CGSDisableUpdate") private func CGSDisableUpdate(_ connection: CGSConnectionID)
@@ -33,6 +38,27 @@ private typealias CGSConnectionID = UInt32
       ?? 0
   }
 
+  public func appKitPointToAXPoint(_ point: CGPoint) -> CGPoint {
+    CGPoint(x: point.x, y: primaryScreenHeight() - point.y)
+  }
+
+  public func windowDebugDescription(_ window: AXUIElement) -> String {
+    var pid: pid_t = 0
+    AXUIElementGetPid(window, &pid)
+    let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "pid:\(pid)"
+
+    var titleRef: AnyObject?
+    let title: String
+    if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
+       let titleValue = titleRef as? String {
+      title = titleValue.isEmpty ? "<untitled>" : titleValue
+    } else {
+      title = "<no title>"
+    }
+
+    return "\(appName) - \"\(title)\""
+  }
+
   // Returns the frontmost (active) window of the currently focused application.
   public func getFrontmostWindow() -> AXUIElement? {
     guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
@@ -47,11 +73,12 @@ private typealias CGSConnectionID = UInt32
       appElement, kAXFocusedWindowAttribute as CFString, &window)
 
     if result == .success, let windowElement = window {
-      logger.debug("successfully got frontmost window for app: \(frontmostApp.localizedName ?? "unknown")")
-      return (windowElement as! AXUIElement)
+      let resolvedWindow = windowElement as! AXUIElement
+      logger.notice("getFrontmostWindow: \(self.windowDebugDescription(resolvedWindow))")
+      return resolvedWindow
     }
 
-    logger.notice("failed to get frontmost window with error: \(result.rawValue)")
+    logger.notice("getFrontmostWindow: failed for app \(frontmostApp.localizedName ?? "unknown"), error=\(result.rawValue)")
     return nil
   }
 
@@ -61,25 +88,43 @@ private typealias CGSConnectionID = UInt32
 
     // NSEvent.mouseLocation uses AppKit coords (origin bottom-left, y up).
     // AXUIElementCopyElementAtPosition uses CG/AX coords (origin top-left, y down).
-    let cgY = primaryScreenHeight() - point.y
+    let axPoint = appKitPointToAXPoint(point)
     let hitResult = AXUIElementCopyElementAtPosition(
       systemWideElement,
-      Float(point.x),
-      Float(cgY),
+      Float(axPoint.x),
+      Float(axPoint.y),
       &hitElementRef
     )
+
+    logger.notice("getWindowAtPoint: AppKit=(\(point.x),\(point.y)) AX=(\(axPoint.x),\(axPoint.y)) result=\(hitResult.rawValue)")
 
     if hitResult == .success,
       let hitElementRef,
       let window = resolveWindowElement(from: hitElementRef)
     {
+      logger.notice("getWindowAtPoint: resolved \(self.windowDebugDescription(window))")
       return window
     }
+
+    logger.notice("getWindowAtPoint: no window resolved")
 
     return nil
   }
 
   public func getWindowFrame(window: AXUIElement) -> CGRect? {
+    guard let axFrame = getAXWindowFrame(window: window) else { return nil }
+
+    let primaryHeight = primaryScreenHeight()
+
+    return CGRect(
+      x: axFrame.position.x,
+      y: primaryHeight - axFrame.position.y - axFrame.size.height,
+      width: axFrame.size.width,
+      height: axFrame.size.height
+    )
+  }
+
+  public func getAXWindowFrame(window: AXUIElement) -> AXWindowFrame? {
     var pid: pid_t = 0
     AXUIElementGetPid(window, &pid)
 
@@ -119,14 +164,9 @@ private typealias CGSConnectionID = UInt32
       AXValueGetValue(sizeValueRef as! AXValue, .cgSize, &size)
     }
 
-    let primaryHeight = primaryScreenHeight()
-
-    return CGRect(
-      x: position.x,
-      y: primaryHeight - position.y - size.height,
-      width: size.width,
-      height: size.height
-    )
+    let axFrame = AXWindowFrame(position: position, size: size)
+    logger.notice("getAXWindowFrame: \(self.windowDebugDescription(window)) -> pos=(\(position.x),\(position.y)) size=(\(size.width),\(size.height))")
+    return axFrame
   }
 
   // Moves and resizes the given window to a new CGRect.
@@ -158,6 +198,18 @@ private typealias CGSConnectionID = UInt32
     let targetSize = CGSize(width: frame.size.width, height: frame.size.height)
 
     applyWindowFrame(window: window, targetPosition: targetPosition, targetSize: targetSize, attempt: 1)
+  }
+
+  public func restoreWindow(window: AXUIElement, axFrame: AXWindowFrame) {
+    logger.notice(
+      "restoreWindow: \(self.windowDebugDescription(window)) -> pos=(\(axFrame.position.x),\(axFrame.position.y)) size=(\(axFrame.size.width),\(axFrame.size.height))"
+    )
+    applyWindowFrame(
+      window: window,
+      targetPosition: axFrame.position,
+      targetSize: axFrame.size,
+      attempt: 1
+    )
   }
 
   private func applyWindowFrame(window: AXUIElement, targetPosition: CGPoint, targetSize: CGSize, attempt: Int) {

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -33,10 +33,37 @@ private typealias CGSConnectionID = UInt32
       ?? 0
   }
 
+  // Returns a debug string for a window: "AppName – WindowTitle @ (x,y,w,h)"
+  public func windowDebugDescription(_ window: AXUIElement) -> String {
+    var pid: pid_t = 0
+    AXUIElementGetPid(window, &pid)
+    let appName = NSRunningApplication(processIdentifier: pid)?.localizedName ?? "pid:\(pid)"
+
+    var titleRef: AnyObject?
+    let title: String
+    if AXUIElementCopyAttributeValue(window, kAXTitleAttribute as CFString, &titleRef) == .success,
+       let t = titleRef as? String {
+      title = t.isEmpty ? "<untitled>" : t
+    } else {
+      title = "<no title>"
+    }
+
+    var posRef: AnyObject?
+    var sizeRef: AnyObject?
+    var pos = CGPoint.zero
+    var size = CGSize.zero
+    if AXUIElementCopyAttributeValue(window, kAXPositionAttribute as CFString, &posRef) == .success,
+       let v = posRef { AXValueGetValue(v as! AXValue, .cgPoint, &pos) }
+    if AXUIElementCopyAttributeValue(window, kAXSizeAttribute as CFString, &sizeRef) == .success,
+       let v = sizeRef { AXValueGetValue(v as! AXValue, .cgSize, &size) }
+
+    return "\(appName) – \"\(title)\" @ (\(Int(pos.x)),\(Int(pos.y)) \(Int(size.width))×\(Int(size.height)))"
+  }
+
   // Returns the frontmost (active) window of the currently focused application.
   public func getFrontmostWindow() -> AXUIElement? {
     guard let frontmostApp = NSWorkspace.shared.frontmostApplication else {
-      logger.notice("failed to get frontmost application")
+      logger.notice("getFrontmostWindow: failed to get frontmost application")
       return nil
     }
 
@@ -47,13 +74,12 @@ private typealias CGSConnectionID = UInt32
       appElement, kAXFocusedWindowAttribute as CFString, &window)
 
     if result == .success, let windowElement = window {
-      logger.debug(
-        "successfully got frontmost window for app: \(frontmostApp.localizedName ?? "unknown")"
-      )
-      return (windowElement as! AXUIElement)
+      let w = windowElement as! AXUIElement
+      logger.debug("getFrontmostWindow: \(windowDebugDescription(w))")
+      return w
     }
 
-    logger.notice("failed to get frontmost window with error: \(result.rawValue)")
+    logger.notice("getFrontmostWindow: failed for app \(frontmostApp.localizedName ?? "unknown"), error=\(result.rawValue)")
     return nil
   }
 
@@ -61,20 +87,36 @@ private typealias CGSConnectionID = UInt32
     let systemWideElement = AXUIElementCreateSystemWide()
     var hitElementRef: AXUIElement?
 
+    // NSEvent.mouseLocation uses AppKit coords (origin bottom-left, y up).
+    // AXUIElementCopyElementAtPosition uses CG/AX coords (origin top-left, y down).
+    let cgY = primaryScreenHeight() - point.y
     let hitResult = AXUIElementCopyElementAtPosition(
       systemWideElement,
       Float(point.x),
-      Float(point.y),
+      Float(cgY),
       &hitElementRef
     )
 
-    if hitResult == .success,
-      let hitElementRef,
-      let window = resolveWindowElement(from: hitElementRef)
-    {
+    logger.debug("getWindowAtPoint: AppKit(\(point.x), \(point.y)) → CG(\(point.x), \(cgY)), AX result=\(hitResult.rawValue)")
+
+    guard hitResult == .success, let hitElementRef else {
+      logger.debug("getWindowAtPoint: hit-test failed (result=\(hitResult.rawValue)) → returning nil")
+      return nil
+    }
+
+    var hitRole = "<unknown>"
+    var roleRef: AnyObject?
+    if AXUIElementCopyAttributeValue(hitElementRef, kAXRoleAttribute as CFString, &roleRef) == .success {
+      hitRole = (roleRef as? String) ?? "<unknown>"
+    }
+    logger.debug("getWindowAtPoint: hit element role=\(hitRole)")
+
+    if let window = resolveWindowElement(from: hitElementRef) {
+      logger.debug("getWindowAtPoint: resolved window → \(windowDebugDescription(window))")
       return window
     }
 
+    logger.debug("getWindowAtPoint: could not resolve AXWindow from hit element → returning nil")
     return nil
   }
 


### PR DESCRIPTION
Hi @gentlespoon,

thank you for merging the PR. 🙏

I had another go at the codebase with a coding agent.
This PR aims to improve the overall UX with two new features and two new preferences.

Pressing ESC now allows the user to exit the snapping overlay after triggering with either not dropping the window off so the user can continue moving the window or (with the setting `Pressing Escape restores the original window frame` enabled) stop the dragging and move the window back to it's original position.

Another setting I added is: `Only allow snapping after the window has already moved`. When enabled the overlay does only engage when the user has actually moved the window before. This could maybe still be improved further if one could somehow detect if a window is currently dragged without it needing to have already been moved before.

The last improvement I added concerns multi-monitor setups. I overhauled this feature to make it possible to drag windows between monitors even while the snapping overlay is engaged. This surely needs some more testing but at least works flawlessly on my machine and setup.

Excited to see what you think of my (aka. the agents) ux improvements.

Best regards,
@lukas-runge

PS: Please do not merge this yet. I am sure this needs some more testing before it's ready for prime time. 🙏