### PR TITLE
fix: make the event monitor self-healing and surface Secure Input

### DIFF
--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -119,6 +119,16 @@ class EventMonitor {
   private func handle(event: CGEvent, type: CGEventType) -> CGEvent? {
     let activateKey = Configuration.shared.activateKey
     switch type {
+    case .tapDisabledByTimeout, .tapDisabledByUserInput:
+      // macOS disables the tap when a callback exceeds its time budget (or on
+      // certain user-input protection events). Without re-enabling here the
+      // monitor stays dead until a manual restart.
+      logger.warning(
+        "event tap disabled by \(type == .tapDisabledByTimeout ? "timeout" : "user input"), re-enabling"
+      )
+      if let eventTap {
+        CGEvent.tapEnable(tap: eventTap, enable: true)
+      }
     case .leftMouseDown:
       logger.debug("left mouse down")
       leftMouseDown()

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -17,12 +17,6 @@ extension Notification.Name {
     "GriddedSecureInputStateDidChange")
 }
 
-//enum DockPosition {
-//  case bottom
-//  case left
-//  case right
-//}
-
 class EventMonitor {
   static let shared = EventMonitor()
 
@@ -39,8 +33,6 @@ class EventMonitor {
   private var runLoopSource: CFRunLoopSource?
   private var watchdogTimer: Timer?
   public private(set) var secureInputActive = false
-  private var isSpacePressed = false
-  private var dragCheckTimer: Timer?
   private var overlayWindow: OverlayWindow?
   private var isDragging: Bool = false
   private var isSnapping: Bool = false
@@ -49,7 +41,6 @@ class EventMonitor {
   private var mouseCoordinatesStart: CGPoint? = nil
   private var mouseCoordinatesEnd: CGPoint? = nil
   private var windowCoordinatesStart: CGPoint? = nil
-  private var windowCoordinatesEnd: CGPoint? = nil
   private var originalWindowAXFrame: AXWindowFrame? = nil
   public private(set) var activeScreen: NSScreen? = nil
   private var snapToCoordinates: CGRect? = nil
@@ -377,7 +368,6 @@ class EventMonitor {
   private func reset() {
     mouseCoordinatesEnd = nil
     mouseCoordinatesStart = nil
-    windowCoordinatesEnd = nil
     windowCoordinatesStart = nil
     frontMostWindow = nil
     originalDraggedWindow = nil
@@ -549,21 +539,7 @@ class EventMonitor {
     }
   }
 
-  // MARK: Coordinates polling
-
-  private func startPollingWindow() {
-    dragCheckTimer?.invalidate()
-    dragCheckTimer = Timer.scheduledTimer(withTimeInterval: 0.2, repeats: true) { _ in
-      self.windowCoordinatesEnd = self.getWindowCoordinates()
-    }
-    logger.debug("window coordinates polling started")
-  }
-
-  private func stopPollingWindow() {
-    dragCheckTimer?.invalidate()
-    dragCheckTimer = nil
-    logger.debug("window coordinates polling stopped")
-  }
+  // MARK: Coordinates
 
   private func getMouseCoordinates() -> CGPoint {
     return NSEvent.mouseLocation

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -6,10 +6,16 @@
 //
 
 import AppKit
+import Carbon
 import Cocoa
 import CoreGraphics
 import Foundation
 import Logging
+
+extension Notification.Name {
+  static let griddedSecureInputStateDidChange = Notification.Name(
+    "GriddedSecureInputStateDidChange")
+}
 
 //enum DockPosition {
 //  case bottom
@@ -32,6 +38,7 @@ class EventMonitor {
   private var eventTap: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
   private var watchdogTimer: Timer?
+  public private(set) var secureInputActive = false
   private var isSpacePressed = false
   private var dragCheckTimer: Timer?
   private var overlayWindow: OverlayWindow?
@@ -142,6 +149,8 @@ class EventMonitor {
   }
 
   private func watchdogTick() {
+    updateSecureInputState()
+
     if let tap = eventTap, !CFMachPortIsValid(tap) {
       logger.warning("watchdog: event tap port invalidated, tearing down")
       stop()
@@ -159,6 +168,38 @@ class EventMonitor {
       logger.info("watchdog: no active event tap, starting")
       start()
     }
+  }
+
+  /// While any app holds Secure Event Input (password fields, Terminal's
+  /// "Secure Keyboard Entry", password managers), the WindowServer withholds
+  /// keyboard events from event taps — mouse events keep flowing. That makes
+  /// keyboard activation silently dead, so we surface the state to the user.
+  private func updateSecureInputState() {
+    let active = IsSecureEventInputEnabled()
+    guard active != secureInputActive else { return }
+    secureInputActive = active
+
+    if active {
+      let holder = secureInputHolderDescription().map { " by \($0)" } ?? ""
+      logger.warning(
+        "secure event input enabled\(holder) — keyboard activation is blocked until it is released"
+      )
+    } else {
+      logger.info("secure event input released")
+    }
+    NotificationCenter.default.post(
+      name: .griddedSecureInputStateDidChange,
+      object: nil,
+      userInfo: ["active": active]
+    )
+  }
+
+  private func secureInputHolderDescription() -> String? {
+    guard let session = CGSessionCopyCurrentDictionary() as? [String: Any],
+      let pid = session["kCGSSessionSecureInputPID"] as? pid_t,
+      let app = NSRunningApplication(processIdentifier: pid)
+    else { return nil }
+    return "\(app.localizedName ?? "unknown app") (pid \(pid))"
   }
 
   // MARK: Event handlers

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -70,6 +70,12 @@ class EventMonitor {
       return
     }
 
+    // Cap synchronous AX round-trips process-wide (set via the system-wide
+    // element). The default of several seconds lets a single busy app stall
+    // the tap callback long enough for macOS to disable the tap by timeout.
+    // Slow window moves are still covered by applyWindowFrame's retry loop.
+    AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), 0.25)
+
     let eventMask =
       (1 << CGEventType.leftMouseDown.rawValue)
       | (1 << CGEventType.leftMouseDragged.rawValue)

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -76,14 +76,14 @@ class EventMonitor {
     // Slow window moves are still covered by applyWindowFrame's retry loop.
     AXUIElementSetMessagingTimeout(AXUIElementCreateSystemWide(), 0.25)
 
+    // Keep this mask minimal: this is an active (filtering) tap, so every
+    // matched event in the entire system waits on our callback.
     let eventMask =
       (1 << CGEventType.leftMouseDown.rawValue)
       | (1 << CGEventType.leftMouseDragged.rawValue)
       | (1 << CGEventType.leftMouseUp.rawValue)
       | (1 << CGEventType.rightMouseDown.rawValue)
       | (1 << CGEventType.keyDown.rawValue)
-      | (1 << CGEventType.keyUp.rawValue)
-      | (1 << CGEventType.mouseMoved.rawValue)
 
     eventTap = CGEvent.tapCreate(
       tap: .cgSessionEventTap,
@@ -183,11 +183,12 @@ class EventMonitor {
       logger.debug("left mouse up")
       leftMouseUp()
     case .leftMouseDragged:
+      // No drag-state polling here: updateDraggingState() does a synchronous
+      // AX round-trip, and drag events arrive at display refresh rate. The
+      // state is computed on demand in startSnapping() instead.
       if isSnapping {
         logger.debug("left mouse dragged")
         leftMouseDragged()
-      } else {
-        updateDraggingState()
       }
     case .rightMouseDown:
       logger.debug("right mouse down")

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -25,9 +25,13 @@ class EventMonitor {
 
   private let logger = Logger(label: "EventMonitor")
 
-  public var isMonitoring: Bool { eventTap != nil }
+  public var isMonitoring: Bool {
+    guard let eventTap else { return false }
+    return CGEvent.tapIsEnabled(tap: eventTap)
+  }
   private var eventTap: CFMachPort?
   private var runLoopSource: CFRunLoopSource?
+  private var watchdogTimer: Timer?
   private var isSpacePressed = false
   private var dragCheckTimer: Timer?
   private var overlayWindow: OverlayWindow?
@@ -50,6 +54,10 @@ class EventMonitor {
    * Start event monitor, should run when app is started.
    */
   func start() {
+    // Watchdog runs even when start() bails (missing permission, tap creation
+    // failure) so the monitor can come up later without user interaction.
+    startWatchdog()
+
     guard eventTap == nil else { return }
 
     let options: NSDictionary = [
@@ -88,9 +96,10 @@ class EventMonitor {
       runLoopSource = CFMachPortCreateRunLoopSource(kCFAllocatorDefault, eventTap, 0)
       CFRunLoopAddSource(CFRunLoopGetCurrent(), runLoopSource, .commonModes)
       CGEvent.tapEnable(tap: eventTap, enable: true)
+      logger.info("event monitor started")
+    } else {
+      logger.error("failed to create event tap, watchdog will retry")
     }
-
-    logger.info("event monitor started")
   }
 
   /**
@@ -112,6 +121,38 @@ class EventMonitor {
     stop()
     reset()
     start()
+  }
+
+  // MARK: Watchdog
+
+  private func startWatchdog() {
+    guard watchdogTimer == nil else { return }
+    let timer = Timer(timeInterval: 5.0, repeats: true) { [weak self] _ in
+      self?.watchdogTick()
+    }
+    // .common so the watchdog also fires during menu tracking and modal panels.
+    RunLoop.main.add(timer, forMode: .common)
+    watchdogTimer = timer
+  }
+
+  private func watchdogTick() {
+    if let tap = eventTap, !CFMachPortIsValid(tap) {
+      logger.warning("watchdog: event tap port invalidated, tearing down")
+      stop()
+    }
+
+    if let tap = eventTap {
+      if !CGEvent.tapIsEnabled(tap: tap) {
+        logger.warning("watchdog: event tap disabled, re-enabling")
+        CGEvent.tapEnable(tap: tap, enable: true)
+      }
+    } else if AXIsProcessTrusted() {
+      // Covers: permission granted after launch, tap creation failure,
+      // teardown after trust loss. Guarded by trust check so the permission
+      // alert in start() never spams from the watchdog.
+      logger.info("watchdog: no active event tap, starting")
+      start()
+    }
   }
 
   // MARK: Event handlers
@@ -478,7 +519,13 @@ class EventMonitor {
 
     var value: AnyObject?
     guard AXIsProcessTrusted() else {
-      restart()
+      // Never restart synchronously from here: this runs inside the tap
+      // callback, and stop() would invalidate the mach port whose callback
+      // is currently executing.
+      logger.warning("accessibility trust lost, scheduling monitor restart")
+      DispatchQueue.main.async { [weak self] in
+        self?.restart()
+      }
       return nil
     }
 

--- a/Gridded/EventMonitor.swift
+++ b/Gridded/EventMonitor.swift
@@ -274,9 +274,10 @@ class EventMonitor {
       // event-tap callback returns so the mouseUp propagates to the app first.
       // The target app's drag handler needs time to process the mouseUp and
       // exit its drag state; applyWindowFrame retries if the app reverts changes.
-      let window = self.frontMostWindow!
-      let screen = activeScreen!
-      let frame = snapToCoordinates!
+      guard let window = frontMostWindow,
+        let screen = activeScreen,
+        let frame = snapToCoordinates
+      else { return reset() }
       reset()
       DispatchQueue.main.asyncAfter(deadline: .now() + 0.15) {
         WindowManager.shared.setWindow(window: window, screen: screen, frame: frame)
@@ -316,16 +317,18 @@ class EventMonitor {
 
     mouseCoordinatesEnd = currentMouse
 
-    snapToCoordinates = ScreenManager.shared.convertCoordinates(
-      coords: (start: mouseCoordinatesStart!, end: mouseCoordinatesEnd!),
+    guard let mouseStart = mouseCoordinatesStart else { return }
+    let snapTo = ScreenManager.shared.convertCoordinates(
+      coords: (start: mouseStart, end: currentMouse),
       screen: activeScreen
     )
-    updateOverlayPreview(snapToCoordinates: snapToCoordinates!)
-    if Configuration.shared.moveOnActivate {
+    snapToCoordinates = snapTo
+    updateOverlayPreview(snapToCoordinates: snapTo)
+    if Configuration.shared.moveOnActivate, let frontMostWindow {
       WindowManager.shared.setWindow(
-        window: self.frontMostWindow!,
+        window: frontMostWindow,
         screen: activeScreen,
-        frame: snapToCoordinates!
+        frame: snapTo
       )
     }
   }
@@ -371,24 +374,33 @@ class EventMonitor {
       }
       frontMostWindow = snapWindow
     }
-    windowCoordinatesStart = getWindowCoordinates()
-    mouseCoordinatesStart = getMouseCoordinates()
-    mouseCoordinatesEnd = mouseCoordinatesStart
 
-    snapToCoordinates = ScreenManager.shared.convertCoordinates(
-      coords: (start: mouseCoordinatesStart!, end: mouseCoordinatesStart!),
-      screen: activeScreen!
+    guard let window = frontMostWindow, let screen = activeScreen else {
+      logger.warning("startSnapping: no window resolved, aborting snap")
+      isSnapping = false
+      return
+    }
+
+    windowCoordinatesStart = getWindowCoordinates()
+    let mouseStart = getMouseCoordinates()
+    mouseCoordinatesStart = mouseStart
+    mouseCoordinatesEnd = mouseStart
+
+    let snapTo = ScreenManager.shared.convertCoordinates(
+      coords: (start: mouseStart, end: mouseStart),
+      screen: screen
     )
+    snapToCoordinates = snapTo
 
     // Show initial overlay preview
     if Configuration.shared.moveOnActivate {
       WindowManager.shared.setWindow(
-        window: self.frontMostWindow!,
-        screen: activeScreen!,
-        frame: snapToCoordinates!
+        window: window,
+        screen: screen,
+        frame: snapTo
       )
     }
-    updateOverlayPreview(snapToCoordinates: snapToCoordinates!)
+    updateOverlayPreview(snapToCoordinates: snapTo)
   }
 
   private func captureWindowForCurrentDrag() {

--- a/Gridded/StatusBarController.swift
+++ b/Gridded/StatusBarController.swift
@@ -21,6 +21,15 @@ final class StatusBarController {
       button.image = NSImage(systemSymbolName: "grid", accessibilityDescription: "Gridded")
     }
 
+    NotificationCenter.default.addObserver(
+      forName: .griddedSecureInputStateDidChange,
+      object: nil,
+      queue: .main
+    ) { [weak self] notification in
+      let active = notification.userInfo?["active"] as? Bool ?? false
+      self?.updateSecureInputIndicator(active: active)
+    }
+
     let menu = NSMenu(title: "Gridded")
     menu.addItem(
       NSMenuItem(
@@ -73,6 +82,24 @@ final class StatusBarController {
 
   @objc private func restartEventMonitor() {
     EventMonitor.shared.restart()
+  }
+
+  private func updateSecureInputIndicator(active: Bool) {
+    guard let button = statusItem.button else { return }
+    if active {
+      button.image =
+        NSImage(
+          systemSymbolName: "keyboard.slash",
+          accessibilityDescription: "Gridded — keyboard activation blocked")
+        ?? NSImage(
+          systemSymbolName: "exclamationmark.triangle",
+          accessibilityDescription: "Gridded — keyboard activation blocked")
+      button.toolTip =
+        "Secure Input is active in another app — keyboard activation (e.g. Space) is blocked until it is released."
+    } else {
+      button.image = NSImage(systemSymbolName: "grid", accessibilityDescription: "Gridded")
+      button.toolTip = nil
+    }
   }
 
   @objc private func openAbout() {

--- a/Gridded/WindowManager.swift
+++ b/Gridded/WindowManager.swift
@@ -21,11 +21,6 @@ struct AXWindowFrame {
   var size: CGSize
 }
 
-private typealias CGSConnectionID = UInt32
-@_silgen_name("CGSMainConnectionID") private func CGSMainConnectionID() -> CGSConnectionID
-@_silgen_name("CGSDisableUpdate") private func CGSDisableUpdate(_ connection: CGSConnectionID)
-@_silgen_name("CGSReenableUpdate") private func CGSReenableUpdate(_ connection: CGSConnectionID)
-
 @Observable class WindowManager {
 
   static let shared = WindowManager()


### PR DESCRIPTION
Hi @gentlespoon,

after reproducing this a bunch of times I let @claude finally have a look at it. Currently testing it, but seems to work fine. Feel free to also have a look and refine if you have any other ideas on why the frequent event monitor restarts have been necessary since my last PR.

Best regards,
@lukas-runge

## Problem

The event monitor regularly died and needed a manual restart via the menu. Separately, sometimes right-click activation kept working while the activation key (Space) appeared dead.

## Root causes

**1. Tap disabled by macOS, never re-enabled.** The tap is an active filter, so every matched event waits on our callback. The callback did synchronous AX IPC on every click system-wide and on every `leftMouseDragged` event (hundreds/sec), with the default AX messaging timeout of ~6 s per call to a busy app. Once a callback exceeded the tap's time budget, macOS sent `tapDisabledByTimeout` — which fell into the `default:` switch case, so the tap stayed dead until a manual restart.

**2. Secure Event Input.** While any app holds Secure Input (browser password fields, Terminal's Secure Keyboard Entry, password managers), the WindowServer withholds keyboard events from event taps while mouse events keep flowing — exactly the "right-click works, Space doesn't" asymmetry. Not a code bug, but the app gave no indication of it.

## Changes (one commit each, in order)

1. **Re-enable the tap** when `tapDisabledByTimeout` / `tapDisabledByUserInput` arrives in the callback.
2. **Watchdog (5 s)**: re-enables a disabled tap, tears down an invalidated mach port, and starts the monitor once accessibility trust exists (covers login autostart before permission is granted, silent `tapCreate` failure, trust loss after re-signing). `isMonitoring` now reports the real tap state; trust-loss restart no longer runs inside the tap callback.
3. **Cap AX messaging timeout at 250 ms** so a single beachballing app can no longer stall the callback past the tap's time budget.
4. **Cut callback load**: drop unhandled `mouseMoved`/`keyUp` from the event mask; stop polling the AX window position on every drag event (the drag state is recomputed on demand in `startSnapping()`, so behavior is unchanged).
5. **Remove force unwraps** from the snapping flow — `frontMostWindow` can legitimately be nil and crashed the app before.
6. **Detect Secure Input** in the watchdog, log which app holds it, and switch the status bar icon with an explanatory tooltip while it is active.
7. **Remove dead code** (unused polling, `isSpacePressed`, unused private CGS API declarations).

## Testing

Manually tested on macOS 15: snapping via Space and right-click (with and without `moveOnActivate`), Escape cancel, multi-monitor drags, and the Secure Input flow (Terminal → Secure Keyboard Entry → status bar indicator appears within ~5 s, Space blocked while right-click keeps working, everything reverts on release).

🤖 Generated with [Claude Code](https://claude.com/claude-code)